### PR TITLE
hotfix: remove unsupported rootDirectory from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,5 @@
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "installCommand": "npm install",
-  "framework": "nextjs",
-  "rootDirectory": "frontend"
+  "framework": "nextjs"
 }
-


### PR DESCRIPTION
🔧 Hotfix: Remove unsupported rootDirectory property from vercel.json
📝 Descripción

Se elimina la propiedad rootDirectory del archivo vercel.json debido a que Vercel dejó de soportarla, lo cual estaba generando el error en el deploy:
Invalid request: should NOT have additional property `rootDirectory`

Este fix permite que el proyecto vuelva a desplegarse correctamente.

✅ Cambios realizados
Eliminación de la propiedad rootDirectory del archivo vercel.json.

🧪 Pruebas
Se verificó que el archivo vercel.json valide correctamente.
Se probó el deploy en Vercel para confirmar la resolución del error.

🛠 Impacto
No afecta la lógica del proyecto.
Solo soluciona un error de configuración que impedía el despliegue.