### PR TITLE
Fix/errors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,15 +9,16 @@
   "scripts": {
     "server": "ts-node-dev --respawn --transpile-only --require tsconfig-paths/register src/index.ts",
     "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "seed": "prisma db seed",
+    "server:dev": "npm run server && npm run prisma:generate && npm run prisma:migrate && npm run seed",
     "build": "npm run prisma:generate && tsc && tsc-alias",
     "start": "node dist/src/index.js",
     "start:prod": "npm run build && node dist/src/index.js",
-    "prisma:migrate": "prisma migrate dev",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,json}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,json}\"",
-    "seed": "prisma db seed"
+    "format:check": "prettier --check \"src/**/*.{ts,json}\""
   },
   "repository": {
     "type": "git",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "seed": "prisma db seed",
-    "server:dev": "npm run server && npm run prisma:generate && npm run prisma:migrate && npm run seed",
+    "server:dev": "npm run prisma:generate && npm run prisma:migrate && npm run seed && npm run server",
     "build": "npm run prisma:generate && tsc && tsc-alias",
     "start": "node dist/src/index.js",
     "start:prod": "npm run build && node dist/src/index.js",

--- a/backend/src/modules/auth/auth.docs.ts
+++ b/backend/src/modules/auth/auth.docs.ts
@@ -55,6 +55,20 @@ export const authDocs = {
           },
         },
       },
+      SignOutResponse: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", example: true },
+          statusCode: { type: "number", example: 200 },
+          message: { type: "string", example: "Sesión cerrada exitosamente" },
+          data: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: true },
+            },
+          },
+        },
+      },
       ErrorResponse: {
         type: "object",
         properties: {
@@ -157,6 +171,21 @@ export const authDocs = {
                 schema: { $ref: "#/components/schemas/ErrorResponse" } 
               } 
             } 
+          },
+        },
+      },
+    },
+    "/api/v1/auth/sign-out": {
+      post: {
+        tags: ["Auth"],
+        summary: "Cerrar sesión",
+        description: "Cierra la sesión del usuario actual. Principalmente se maneja del lado del cliente eliminando los tokens del localStorage.",
+        responses: {
+          200: {
+            description: "Sesión cerrada exitosamente",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/SignOutResponse" } },
+            },
           },
         },
       },

--- a/backend/src/modules/colecciones/coleccion.service.ts
+++ b/backend/src/modules/colecciones/coleccion.service.ts
@@ -3,58 +3,76 @@ import { coleccionRepository } from "./coleccion.repository";
 import { CreateColeccionDto, UpdateColeccionDto } from "./coleccion.schema";
 
 export const coleccionService = {
-    create: async (data: CreateColeccionDto) => {
-        const exists = await coleccionRepository.findByName(data.nombre);
-        if (exists) {
-        throw new AppError("La colección ya existe", 409);
-        }
+  create: async (data: CreateColeccionDto) => {
+    const exists = await coleccionRepository.findByName(data.nombre);
+    if (exists) {
+      throw new AppError("La colección ya existe", 409);
+    }
 
-        const last = await coleccionRepository.findLast();
-        const nextCodigo = last ? last.codigo + 1 : 1;
+    const last = await coleccionRepository.findLast();
+    const nextCodigo = last ? last.codigo + 1 : 1;
 
-        const payload = {
-        ...data,
-        codigo: nextCodigo,
-        };
+    const payload = {
+      ...data,
+      codigo: nextCodigo,
+    };
 
-        return await coleccionRepository.create(payload);
-    },
+    return await coleccionRepository.create(payload);
+  },
 
-    getAll: () => coleccionRepository.findAll(),
+  getAll: () => coleccionRepository.findAll(),
 
-    getById: async (id: number) => {
-        if (!id || isNaN(id)) {
-        throw new AppError("ID inválido", 400);
-        }
+  getById: async (id: number) => {
+    if (!id || isNaN(id)) {
+      throw new AppError("ID inválido", 400);
+    }
 
-        const coleccion = await coleccionRepository.findById(id, {
-        include: {
-            productos: true,
-        },
-        });
+    const coleccion = await coleccionRepository.findById(id, {
+      include: {
+        productos: true,
+      },
+    });
 
-        if (!coleccion) {
-        throw new AppError("Colección no encontrada", 404);
-        }
+    if (!coleccion) {
+      throw new AppError("Colección no encontrada", 404);
+    }
 
-        return coleccion;
-    },
+    return coleccion;
+  },
 
-    update: async (id: number, data: UpdateColeccionDto) => {
-        await coleccionService.getById(id);
+  update: async (id: number, data: UpdateColeccionDto) => {
+    await coleccionService.getById(id);
 
-        if (data.nombre) {
-        const exists = await coleccionRepository.findByName(data.nombre);
-        if (exists && exists.id !== id) {
-            throw new AppError("Ya existe una colección con ese nombre", 409);
-        }
-        }
+    if (data.nombre) {
+      const exists = await coleccionRepository.findByName(data.nombre);
+      if (exists && exists.id !== id) {
+        throw new AppError("Ya existe una colección con ese nombre", 409);
+      }
+    }
 
-        return coleccionRepository.update(id, data);
-    },
+    return coleccionRepository.update(id, data);
+  },
 
-    delete: async (id: number) => {
-        await coleccionService.getById(id); // valida existencia
-        return coleccionRepository.delete(id);
-    },
+  delete: async (id: number) => {
+    const coleccion = await coleccionService.getById(id);
+
+    if (coleccion.productos && coleccion.productos.length > 0) {
+      throw new AppError(
+        `No se puede eliminar la colección "${coleccion.nombre}" porque tiene ${coleccion.productos.length} producto(s) asociado(s). Elimine primero los productos de esta colección.`,
+        409
+      );
+    }
+
+    try {
+      return await coleccionRepository.delete(id);
+    } catch (error: any) {
+      if (error?.code === "P2003" || error?.code === "23001") {
+        throw new AppError(
+          `No se puede eliminar la colección "${coleccion.nombre}" porque tiene productos asociados. Elimine primero los productos de esta colección.`,
+          409
+        );
+      }
+      throw error;
+    }
+  },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "dev:prod": "npm run build && npm run start",
     "lint": "eslint"
   },
   "dependencies": {

--- a/frontend/src/app/colecciones/verano/page.tsx
+++ b/frontend/src/app/colecciones/verano/page.tsx
@@ -11,19 +11,19 @@ import CollectionCard from '@/components/common/CollectionCard';
 import AddFloatingButton from '@/components/common/AddFloatingButton';
 import { useAuth } from '@/hooks/useAuth';
 import { useSidebar } from '@/hooks/useSidebar';
-import { useCollections } from '@/hooks/useCollections';
+import { useProducts } from '@/hooks/useProducts';
 
 export default function SummerPage() {
   const router = useRouter();
   const { user, mounted } = useAuth();
   const { isOpen: isSidebarOpen, open: openSidebar, close: closeSidebar } = useSidebar();
   const {
-    filteredGarments,
-    garmentSearchQuery,
-    handleGarmentSearch,
-    handleGarmentClick,
-    handleAddGarment,
-  } = useCollections();
+    filteredProducts,
+    searchQuery: garmentSearchQuery,
+    handleSearch: handleGarmentSearch,
+    handleProductClick,
+    handleAddProduct,
+  } = useProducts();
 
   if (!mounted) {
     return null;
@@ -57,22 +57,22 @@ export default function SummerPage() {
             </div>
 
             <div className="space-y-2 sm:space-y-3 md:space-y-4 pb-4 sm:pb-5 md:pb-6">
-              {filteredGarments.map((garment) => (
+              {filteredProducts.map((product) => (
                 <CollectionCard
-                  key={garment.id}
-                  id={garment.id}
-                  name={garment.name}
-                  color={garment.color}
-                  size={garment.size}
-                  price={garment.price}
-                  imageUrl={garment.imageUrl}
-                  onClick={() => handleGarmentClick(garment.id)}
+                  key={product.id}
+                  id={String(product.id)}
+                  name={product.nombre}
+                  color={product.colores.length > 0 ? product.colores.join(', ') : 'Sin color'}
+                  size={product.tallas.length > 0 ? product.tallas.join(', ') : 'Sin talla'}
+                  price={`$${product.mermaPrecio || 0}`}
+                  imageUrl={product.imagen || '/placeholder-image.png'}
+                  onClick={() => handleProductClick(product.id)}
                 />
               ))}
             </div>
 
             <div className="pt-4 sm:pt-5 md:pt-6 pb-6 sm:pb-8 md:pb-10">
-              <AddFloatingButton onClick={handleAddGarment} isStatic={true} />
+              <AddFloatingButton onClick={() => handleAddProduct()} isStatic={true} />
             </div>
           </div>
         </div>

--- a/frontend/src/services/collection.service.ts
+++ b/frontend/src/services/collection.service.ts
@@ -119,7 +119,11 @@ export const collectionService = {
             })
 
             if (!response.ok) {
-                throw new Error(`Error ${response.status}: ${response.statusText}`)
+                const errorData = await response.json().catch(() => ({}))
+                throw new Error(
+                    errorData.message ||
+                    `Error ${response.status}: ${response.statusText}`
+                )
             }
 
         } catch (error: unknown) {


### PR DESCRIPTION
# He corregido errores en el frontend y agregado funcionalidades:

- Ahora se puede hacer `npm run dev:prod` para probar y determinar errores no reconocidos durante **dev** como si se desplegará.
- Arreglado el error cuando se intenta eliminar una **colección** teniendo **prendas** relacionadas, se agrego una notificación tipo Toast Error para el aviso.

# He corregido errores en el backend y agregado funcionalidades:

- Ahora se puede hacer `npm run server:dev` para realizar tanto la generación de los schemas, como la migración, la población de la base de datos, y la ejecución en local de desarrollo.
- Ahora hay validaciones en **colecciones** que validan si el la colección tiene prendas relacionadas.