### PR TITLE
Ajuste para la creación de ficha de prenda y mejorar de gestión de productos y materiales en colecciones.

### DIFF
--- a/backend/src/modules/material/material.schema.ts
+++ b/backend/src/modules/material/material.schema.ts
@@ -46,7 +46,7 @@ export const materialIdSchema = z.object({
 
 // Query params (filtros)
 export const materialQuerySchema = z.object({
-  body: z.object({}),
+  body: z.object({}).optional(),
   query: z.object({
     color: z.string().optional(),
     precioMin: z

--- a/backend/src/modules/producto/producto.service.ts
+++ b/backend/src/modules/producto/producto.service.ts
@@ -19,6 +19,7 @@ export const productoService = {
       nombre: data.nombre,
       descripcion: data.descripcion,
       activo: data.activo,
+      imagen: data.imagen,
       coleccionId: data.coleccionId,
       tallas: data.tallas,
       colores: data.colores,

--- a/backend/src/modules/producto/producto.types.ts
+++ b/backend/src/modules/producto/producto.types.ts
@@ -4,6 +4,7 @@ export interface CreateProductoDtoDB {
     nombre: string;
     descripcion?: string | null;
     activo?: boolean;
+    imagen?: string | null;
     tallas?: string[];
     colores?: string[];
   }

--- a/frontend/src/app/colecciones/[slug]/page.tsx
+++ b/frontend/src/app/colecciones/[slug]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Header from '@/components/common/Header';
 import Footer from '@/components/common/Footer';
@@ -8,17 +7,17 @@ import Sidebar from '@/components/common/Sidebar';
 import BackNavigationBar from '@/components/common/BackNavigationBar';
 import SearchBarWhite from '@/components/common/SearchBarWhite';
 import ProductCard from '@/components/common/ProductCard';
-import AddFloatingButton from '@/components/common/AddFloatingButton';
 import { useAuth } from '@/hooks/useAuth';
 import { useSidebar } from '@/hooks/useSidebar';
 import { useProducts } from '@/hooks/useProducts';
 import { useCollections } from '@/hooks';
+import BtnActionsProducts from '@/components/ui/BtnActionsProducts';
 
 export default function CollectionDetailPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const collectionId = searchParams.get('id');
-  
+
   const { user, mounted } = useAuth();
   const { isOpen: isSidebarOpen, open: openSidebar, close: closeSidebar } = useSidebar();
 
@@ -41,7 +40,7 @@ export default function CollectionDetailPage() {
   } = useProducts({
     collectionId: collectionId ? Number(collectionId) : undefined
   });
-  
+
 
   if (!mounted) {
     return null;
@@ -67,7 +66,7 @@ export default function CollectionDetailPage() {
       <div className="min-h-screen flex flex-col bg-[#E6E1EA]">
         <Header onMenuClick={openSidebar} />
         <Sidebar isOpen={isSidebarOpen} onClose={closeSidebar} />
-        
+
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center p-6">
             <p className="text-gray-600 text-lg mb-4">
@@ -81,7 +80,7 @@ export default function CollectionDetailPage() {
             </button>
           </div>
         </div>
-        
+
         <Footer />
       </div>
     );
@@ -102,7 +101,7 @@ export default function CollectionDetailPage() {
 
         <div className="bg-[#E6E1EA] rounded-t-2xl py-3 sm:py-4 md:py-5 flex-1">
           <div className="w-[calc(100%-2rem)] sm:w-[calc(100%-4rem)] max-w-xs sm:max-w-sm mx-auto">
-            
+
             <div className="mb-3 sm:mb-4 md:mb-5 pt-3 sm:pt-4 md:pt-5">
               <SearchBarWhite
                 placeholder="Buscar color, precio..."
@@ -163,15 +162,18 @@ export default function CollectionDetailPage() {
               </>
             )}
 
-            <div className="pt-4 sm:pt-5 md:pt-6 pb-6 sm:pb-8 md:pb-10">
+            {/* <div className="pt-4 sm:pt-5 md:pt-6 pb-6 sm:pb-8 md:pb-10">
               <AddFloatingButton 
                 onClick={() => handleAddProduct(currentCollection.id)} 
                 isStatic={true} 
               />
-            </div>
+            </div> */}
           </div>
         </div>
       </div>
+      <BtnActionsProducts
+        onAddProduct={() => handleAddProduct(currentCollection.id)}
+      />
       <Footer />
     </div>
   );

--- a/frontend/src/app/colecciones/crear/page.tsx
+++ b/frontend/src/app/colecciones/crear/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useSearchParams } from 'next/navigation';
+import AddGarmentTemplate from '@/components/common/AddGarmentTemplate'
+
+function AddGarmentPage() {
+  const searchParams = useSearchParams();
+  const collectionId = searchParams.get('coleccionId');
+
+  return (
+    <>
+        <AddGarmentTemplate collectionId={collectionId ? Number(collectionId) : undefined}/>
+    </>
+  )
+}
+
+export default AddGarmentPage

--- a/frontend/src/app/colecciones/verano/page.tsx
+++ b/frontend/src/app/colecciones/verano/page.tsx
@@ -1,29 +1,20 @@
 'use client';
 
-import React from 'react';
 import { useRouter } from 'next/navigation';
 import Header from '@/components/common/Header';
 import Footer from '@/components/common/Footer';
 import Sidebar from '@/components/common/Sidebar';
 import BackNavigationBar from '@/components/common/BackNavigationBar';
 import SearchBarWhite from '@/components/common/SearchBarWhite';
-import CollectionCard from '@/components/common/CollectionCard';
 import AddFloatingButton from '@/components/common/AddFloatingButton';
 import { useAuth } from '@/hooks/useAuth';
 import { useSidebar } from '@/hooks/useSidebar';
-import { useCollections } from '@/hooks/useCollections';
 
 export default function SummerPage() {
   const router = useRouter();
   const { user, mounted } = useAuth();
   const { isOpen: isSidebarOpen, open: openSidebar, close: closeSidebar } = useSidebar();
-  const {
-    filteredGarments,
-    garmentSearchQuery,
-    handleGarmentSearch,
-    handleGarmentClick,
-    handleAddGarment,
-  } = useCollections();
+
 
   if (!mounted) {
     return null;
@@ -51,28 +42,17 @@ export default function SummerPage() {
             <div className="mb-3 sm:mb-4 md:mb-5 pt-3 sm:pt-4 md:pt-5">
               <SearchBarWhite
                 placeholder="Buscar color, precio..."
-                value={garmentSearchQuery}
-                onChange={handleGarmentSearch}
+                value={''}
+                onChange={() => {}}
               />
             </div>
 
             <div className="space-y-2 sm:space-y-3 md:space-y-4 pb-4 sm:pb-5 md:pb-6">
-              {filteredGarments.map((garment) => (
-                <CollectionCard
-                  key={garment.id}
-                  id={garment.id}
-                  name={garment.name}
-                  color={garment.color}
-                  size={garment.size}
-                  price={garment.price}
-                  imageUrl={garment.imageUrl}
-                  onClick={() => handleGarmentClick(garment.id)}
-                />
-              ))}
+              
             </div>
 
             <div className="pt-4 sm:pt-5 md:pt-6 pb-6 sm:pb-8 md:pb-10">
-              <AddFloatingButton onClick={handleAddGarment} isStatic={true} />
+              <AddFloatingButton onClick={() => { router.push('/colecciones/verano/crear-coleccion') }} isStatic={true} />
             </div>
           </div>
         </div>

--- a/frontend/src/components/common/AddGarmentTemplate.tsx
+++ b/frontend/src/components/common/AddGarmentTemplate.tsx
@@ -6,7 +6,11 @@ import { useAuth, useSidebar } from '@/hooks';
 import BackNavigationBar from './BackNavigationBar';
 import GarmentForm from './GarmentForm';
 
-export default function AddGarmentTemplate() {
+interface AddGarmentTemplateProps {
+    collectionId?: number; 
+}
+
+export default function AddGarmentTemplate({ collectionId }: AddGarmentTemplateProps) {
     const { user, mounted } = useAuth();
     const { isOpen: isSidebarOpen, open: openSidebar, close: closeSidebar } = useSidebar();
 
@@ -27,7 +31,7 @@ export default function AddGarmentTemplate() {
                         ]}
                     />
 
-                    <GarmentForm />
+                    <GarmentForm collectionId={collectionId}/>
                 </div>
             </main>
         </div>

--- a/frontend/src/components/common/GarmentForm.tsx
+++ b/frontend/src/components/common/GarmentForm.tsx
@@ -1,5 +1,4 @@
 "use client"
-import React from 'react'
 import ImageUploadField from '../ui/ImageUploadField'
 import GarmentDetailTabForm from '../ui/GarmentDetailTabForm';
 import RawMaterialTabForm from '../ui/RawMaterialTabForm';
@@ -8,10 +7,17 @@ import { useAddGarmentForm, useImageUpload } from '@/hooks';
 import TabNavigation from '../ui/TabNavigation';
 import GarmentInfoCard from '../ui/GarmentInfoCard';
 import { AlertCircle, Loader2 } from 'lucide-react';
+import { useToast } from '@/contexts/ToastContext';
 
-export default function GarmentForm() {
+interface GarmentFormProps {
+    collectionId?: number; 
+}
 
-    const { activeTab, tabs, setActiveTab, form, setValue, errors, submit, isSubmitting, submitError } = useAddGarmentForm();
+export default function GarmentForm({ collectionId }: GarmentFormProps) {
+
+    const toast = useToast();
+
+    const { activeTab, tabs, setActiveTab, form, setValue, errors, submit, isSubmitting, submitError } = useAddGarmentForm(collectionId);
 
     const {
         imagePreview,
@@ -62,10 +68,10 @@ export default function GarmentForm() {
             
             if (hasDetailErrors) {
                 setActiveTab(0); 
-                alert('Por favor completa todos los campos obligatorios en "Detalle prenda"');
+                toast.showWarning('Por favor completa todos los campos obligatorios en "Detalle prenda"');
             } else if (hasMaterialErrors) {
                 setActiveTab(1); 
-                alert('Debes agregar al menos un material (tela o insumo)');
+                toast.showWarning('Debes agregar al menos un material (tela o insumo)');
             }
         }
     }

--- a/frontend/src/components/ui/BtnActionsProducts.tsx
+++ b/frontend/src/components/ui/BtnActionsProducts.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { Plus, Trash2, XCircleIcon } from "lucide-react";
+
+interface BtnActionsProductsProps {
+  productsToDelete?: Set<number>;
+  isDeleteMode?: boolean;
+  toggleDeleteMode?: () => void;
+  confirmDeletion?: () => void;
+  onAddProduct?: () => void;
+}
+
+export default function BtnActionsProducts({  isDeleteMode, toggleDeleteMode, onAddProduct }: BtnActionsProductsProps) {
+
+
+  return (
+    <div className="fixed bg-primary-300 p-2 bottom-20 right-1/2 transform translate-x-1/2 flex gap-3 rounded-full z-50">
+      <button
+        type="button"
+        onClick={onAddProduct}
+        className="px-4 py-2 bg-secondary-500 hover:bg-secondary-600 rounded-full text-white shadow-lg transition-colors font-medium text-sm flex items-center gap-2 whitespace-nowrap"
+      >
+        <Plus className="w-4 h-4" />
+      </button>
+      {!isDeleteMode ? (
+        <button
+          onClick={toggleDeleteMode}
+          className="w-12 h-12 sm:w-14 sm:h-14 bg-primary-500 hover:bg-primary-600 rounded-full flex items-center justify-center text-white shadow-lg transition-colors"
+          title="Modo eliminar"
+        >
+          <Trash2 className="w-5 h-5 sm:w-6 sm:h-6" />
+        </button>
+      ) : (
+        <button
+          onClick={toggleDeleteMode}
+          className="px-4 py-2 bg-gray-500 hover:bg-gray-600 rounded-full text-white shadow-lg transition-colors font-medium text-sm"
+        >
+          <XCircleIcon className="w-5 h-5 sm:w-6 sm:h-6" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/RawMaterialTabForm.tsx
+++ b/frontend/src/components/ui/RawMaterialTabForm.tsx
@@ -8,6 +8,8 @@ import CustomSelect from './CustomSelect';
 import CustomInputWithSelect from './CustomInputWithSelect';
 import PriceDisplay from './PriceDisplay';
 import { Plus, Trash2 } from 'lucide-react';
+import { useMaterials } from '@/hooks/useMaterialsForService';
+import { useToast } from '@/contexts/ToastContext';
 
 interface RawMaterialTabFormProps {
     form: UseFormReturn<GarmentFormData>;
@@ -15,54 +17,61 @@ interface RawMaterialTabFormProps {
 
 const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
     const { register, watch, setValue, formState: { errors } } = form;
+    const { materials, isLoading: loadingMaterials } = useMaterials();
+    const toast = useToast();
 
     const rawMaterials = watch('rawMaterials') || [];
+
+    const fabricMaterialsFromDB = materials.filter(m => m.categoria?.nombre === 'TELA' || m.categoria?.nombre === 'tela');
+    const supplyMaterialsFromDB = materials.filter(m => m.categoria?.nombre === 'INSUMO' || m.categoria?.nombre === 'insumo');
 
     const fabricMaterials = rawMaterials.filter(m => m.type === 'fabric');
     const supplyMaterials = rawMaterials.filter(m => m.type === 'supply');
 
-    const totalPrice = rawMaterials.reduce((sum, material) => sum + material.price, 0);
+    const totalPrice = rawMaterials.reduce((sum, material) => sum + (material.price ?? 0), 0);
 
-    const fabrics = [
-        { value: 'algodon', label: 'Algodón' },
-        { value: 'poliester', label: 'Poliéster' },
-        { value: 'seda', label: 'Seda' },
-    ];
 
-    const supplies = [
-        { value: 'botones', label: 'Botones' },
-        { value: 'cremalleras', label: 'Cremalleras' },
-        { value: 'hilos', label: 'Hilos' },
-    ];
+    const fabricOptions = fabricMaterialsFromDB.map(m => ({
+        value: m.id.toString(),
+        label: m.nombre
+    }));
+
+    const supplyOptions = supplyMaterialsFromDB.map(m => ({
+        value: m.id.toString(),
+        label: m.nombre
+    }));
 
     const addFabric = () => {
-        const name = watch('tempFabricName');
+        const materialIdStr = watch('tempFabricName');
         const consumption = watch('tempFabricConsumption');
         const unit = watch('tempFabricUnit');
         const price = watch('tempFabricPrice');
 
-        if (!name || !consumption || !unit || !price) {
-            alert('Por favor completa todos los campos de tela');
+        if (!materialIdStr || !consumption || !unit) {
+            toast.showWarning('Por favor completa todos los campos de tela');
             return;
         }
 
         if (consumption <= 0) {
-            alert('El consumo debe ser mayor a 0');
+            toast.showWarning('El consumo debe ser mayor a 0');
             return;
         }
 
-        if (price < 0) {
-            alert('El precio debe ser mayor o igual a 0');
+
+        const selectedMaterial = materials.find(m => m.id === parseInt(materialIdStr));
+
+        if (!selectedMaterial) {
+            toast.showWarning('Material no encontrado');
             return;
         }
 
         const newMaterial = {
-            id: `fabric-${Date.now()}`,
+            id: materialIdStr,
             type: 'fabric' as const,
-            name,
+            name: selectedMaterial.nombre,
             consumption,
-            unit,
-            price,
+            unit: selectedMaterial.unidadMedida,
+            price: selectedMaterial.precio * consumption,
         };
 
         setValue('rawMaterials', [...rawMaterials, newMaterial]);
@@ -74,33 +83,36 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
     };
 
     const addSupply = () => {
-        const name = watch('tempSupplyName');
+        const materialIdStr = watch('tempSupplyName');
         const consumption = watch('tempSupplyConsumption');
         const unit = watch('tempSupplyUnit');
-        const price = watch('tempSupplyPrice');
+        // const price = watch('tempSupplyPrice');
 
-        if (!name || !consumption || !unit || !price) {
-            alert('Por favor completa todos los campos de insumo');
+        if (!materialIdStr || !consumption || !unit) {
+            toast.showWarning('Por favor completa todos los campos de insumo');
             return;
         }
 
         if (consumption <= 0) {
-            alert('El consumo debe ser mayor a 0');
+            toast.showWarning('El consumo debe ser mayor a 0');
             return;
         }
 
-        if (price < 0) {
-            alert('El precio debe ser mayor o igual a 0');
+
+        const selectedMaterial = materials.find(m => m.id === parseInt(materialIdStr));
+
+        if (!selectedMaterial) {
+            toast.showWarning('Material no encontrado');
             return;
         }
 
         const newMaterial = {
-            id: `supply-${Date.now()}`,
+            id: materialIdStr,
             type: 'supply' as const,
-            name,
+            name: selectedMaterial.nombre,
             consumption,
-            unit,
-            price,
+            unit: selectedMaterial.unidadMedida,
+            price: selectedMaterial.precio * consumption,
         };
 
         setValue('rawMaterials', [...rawMaterials, newMaterial]);
@@ -128,31 +140,32 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
                 <CustomSelect
                     id="tempFabricName"
                     label="Tela"
-                    options={fabrics}
+                    options={fabricOptions}
                     register={register('tempFabricName')}
                     error={errors.tempFabricName?.message}
                     placeholder="Ej. Algodón"
                     className="bg-white"
                 />
 
-                <div className="grid grid-cols-2 gap-4">
-                    <CustomInputWithSelect
-                        id="tempFabricConsumption"
-                        label="Consumo"
-                        register={register('tempFabricConsumption', { valueAsNumber: true })}
-                        error={errors.tempFabricConsumption?.message}
-                        placeholder="2.00"
-                        selectId="tempFabricUnit"
-                        selectRegister={register('tempFabricUnit')}
-                        selectOptions={[
-                            { value: 'm', label: 'm' },
-                            { value: 'cm', label: 'cm' },
-                        ]}
-                        selectError={errors.tempFabricUnit?.message}
-                        className="bg-white"
-                    />
+                <CustomInputWithSelect
+                    id="tempFabricConsumption"
+                    label="Consumo"
+                    register={register('tempFabricConsumption', { valueAsNumber: true })}
+                    error={errors.tempFabricConsumption?.message}
+                    placeholder="2.00"
+                    selectId="tempFabricUnit"
+                    selectRegister={register('tempFabricUnit')}
+                    selectOptions={[
+                        { value: 'm', label: 'm' },
+                        { value: 'cm', label: 'cm' },
+                    ]}
+                    selectError={errors.tempFabricUnit?.message}
+                    className="bg-white"
+                />
 
-                    <CustomInput
+                <div className="grid grid-cols-2 gap-4">
+
+                    {/* <CustomInput
                         id="tempFabricPrice"
                         label="Precio"
                         type="number"
@@ -161,7 +174,7 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
                         placeholder="25.000"
                         className="bg-white"
                         unit="$"
-                    />
+                    /> */}
                 </div>
 
                 <div className="flex items-center gap-4">
@@ -196,7 +209,7 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
                                     {material.consumption} {material.unit}
                                 </span>
                                 <span className="text-sm font-semibold text-gray-800">
-                                    $ {material.price.toLocaleString('es-CO')}
+                                    $ {material.price}
                                 </span>
                                 <button
                                     type="button"
@@ -215,32 +228,32 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
                 <CustomSelect
                     id="tempSupplyName"
                     label="Insumos"
-                    options={supplies}
+                    options={supplyOptions}
                     register={register('tempSupplyName')}
                     error={errors.tempSupplyName?.message}
                     placeholder="Ej. Botones L24 + cortesía"
                     className="bg-white"
                 />
 
+                <CustomInputWithSelect
+                    id="tempSupplyConsumption"
+                    label="Consumo"
+                    register={register('tempSupplyConsumption', { valueAsNumber: true })}
+                    error={errors.tempSupplyConsumption?.message}
+                    placeholder="4"
+                    selectId="tempSupplyUnit"
+                    selectRegister={register('tempSupplyUnit')}
+                    selectOptions={[
+                        { value: 'm', label: 'm' },
+                        { value: 'cm', label: 'cm' },
+                        { value: 'un', label: 'un' },
+                    ]}
+                    selectError={errors.tempSupplyUnit?.message}
+                    className="bg-white"
+                />
                 <div className="grid grid-cols-2 gap-4">
-                    <CustomInputWithSelect
-                        id="tempSupplyConsumption"
-                        label="Consumo"
-                        register={register('tempSupplyConsumption', { valueAsNumber: true })}
-                        error={errors.tempSupplyConsumption?.message}
-                        placeholder="6"
-                        selectId="tempSupplyUnit"
-                        selectRegister={register('tempSupplyUnit')}
-                        selectOptions={[
-                            { value: 'm', label: 'm' },
-                            { value: 'cm', label: 'cm' },
-                            { value: 'un', label: 'un' },
-                        ]}
-                        selectError={errors.tempSupplyUnit?.message}
-                        className="bg-white"
-                    />
 
-                    <CustomInput
+                    {/* <CustomInput
                         id="tempSupplyPrice"
                         label="Precio"
                         type="number"
@@ -249,7 +262,7 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
                         placeholder="35.000"
                         className="bg-white"
                         unit="$"
-                    />
+                    /> */}
                 </div>
 
                 <div className="flex items-center gap-4">
@@ -283,7 +296,7 @@ const RawMaterialTabForm: React.FC<RawMaterialTabFormProps> = ({ form }) => {
                                         {material.consumption} {material.unit}
                                     </span>
                                     <span className="text-sm font-semibold text-gray-800">
-                                        $ {material.price.toLocaleString('es-CO')}
+                                        $ {material.price}
                                     </span>
                                     <button
                                         type="button"

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -21,6 +21,7 @@ export * from './useCollections';
 export * from './useImageUpload';
 export * from './useLogin';
 export * from './useMaterials';
+export * from './useMaterialsForService';
 export * from './useMaterialSubmit';
 export * from './useNavigationTabs';
 export * from './useOrderCard';

--- a/frontend/src/hooks/useAddGarmentForm.ts
+++ b/frontend/src/hooks/useAddGarmentForm.ts
@@ -1,8 +1,12 @@
+"use client";
 import { useEffect, useState } from 'react';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { GarmentSchema, GarmentFormData, CreateGarmentPayload } from '@/types/IGarment';
 import { garmentService } from '@/services/garment.service';
+import { collectionService } from '@/services/collection.service';
+import { useToast } from '@/contexts/ToastContext';
+import { useRouter } from 'next/navigation';
 
 
 export interface AddGarmentFormState {
@@ -13,13 +17,10 @@ export interface AddGarmentFormState {
 const tabs = ['Detalle prenda', 'Materia prima', 'Producción'] as const;
 
 const generateId = () => {
-    const prefix = '000';
-    const random = Math.floor(Math.random() * 999).toString().padStart(3, '0');
-    const suffix = Math.floor(Math.random() * 99).toString().padStart(2, '0');
-    return `${prefix}-${random}-${suffix}`;
+    return Math.floor(1000 + Math.random() * 9000).toString();
 };
 
-export const useAddGarmentForm = () => {
+export const useAddGarmentForm = (collectionId?: number) => {
     const form = useForm<GarmentFormData>({
         resolver: zodResolver(GarmentSchema),
         defaultValues: {
@@ -34,10 +35,25 @@ export const useAddGarmentForm = () => {
         mode: 'onChange',
     });
 
+    const toast = useToast();
+    const router = useRouter();
+
     const [activeTab, setActiveTab] = useState(0);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (collectionId) {
+            collectionService.getById(collectionId.toString())
+                .then((collection) => {
+                    form.setValue('season', collection.nombre, { shouldValidate: true });
+                })
+                .catch((error) => {
+                    console.error('Error fetching collection:', error);
+                });
+        }
+    }, [collectionId, form]);
 
     useEffect(() => {
         const subscription = form.watch((value) => {
@@ -75,48 +91,45 @@ export const useAddGarmentForm = () => {
         try {
             await new Promise((resolve) => setTimeout(resolve, 2000));
 
-            const payload = {
-                ...data,
+            const payload: CreateGarmentPayload = {
+                codigo: data.id || generateId(),
                 nombre: data.commercialName,
                 descripcion: data.description,
                 activo: true,
+                imagen: data.image,
                 tallas: data.sizes.split(',').map((size) => size.trim()),
                 colores: data.colors.split(',').map((color) => color.trim()),
 
-                rawMaterial: data.rawMaterials,
+                coleccionId: collectionId || 0,
 
-                laborRate: data.laborRate,
-                laborHours: data.laborHours,
-                wasteMaterial: data.wasteMaterial,
-                wasteUnit: data.wasteUnit,
-                wastePrice: data.wastePrice,
+                materiales: data.rawMaterials?.map((m) => ({
+                    materialId: parseInt(m.id),
+                    cantidad: m.consumption
+                })) || [],
 
-                tempFabricName: undefined,
-                tempFabricConsumption: undefined,
-                tempFabricUnit: undefined,
-                tempFabricPrice: undefined,
-                tempSupplyName: undefined,
-                tempSupplyConsumption: undefined,
-                tempSupplyUnit: undefined,
-                tempSupplyPrice: undefined,
+                manoDeObra: data.laborHours && data.laborHours > 0 ? [{
+                    accionId: 1,              
+                    horas: data.laborHours    
+                }] : [],
 
-            } as CreateGarmentPayload;
-
-            console.log('📤 Enviando datos al backend:', payload);
+                mermaCantidad: data.wasteMaterial || 0,
+                mermaUnidad: data.wasteUnit || 'm',
+                mermaPrecio: data.wastePrice || 0,
+            };
 
             await garmentService.create(payload);
 
-            console.log('✅ Request completado (backend puede tener error, pero eso es esperado)', payload);
+            console.log('✅ Producto creado exitosamente');
 
-            alert('✅ Request completado (backend puede tener error, pero eso está en espera)');
+            toast.showSuccess('✅ Producto creado exitosamente!');
             setActiveTab(0);
             form.reset();
+            router.back();
 
         } catch (error) {
-            console.warn('⚠️ Error en la petición (esperado):', error);
             setSubmitError(
-                error instanceof Error 
-                    ? error.message 
+                error instanceof Error
+                    ? error.message
                     : 'Ocurrió un error al guardar la prenda'
             );
         } finally {
@@ -134,12 +147,9 @@ export const useAddGarmentForm = () => {
         setValue: form.setValue,
         register: form.register,
         errors: form.formState.errors,
-        // submit: form.handleSubmit((data) => {
-        //     console.log('Formulario enviado:', data);
-        // }),
         isSubmitting,
         submitError,
         submit: form.handleSubmit(handleSubmit),
-    
+
     };
 };

--- a/frontend/src/hooks/useMaterialsForService.ts
+++ b/frontend/src/hooks/useMaterialsForService.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { Material } from '@/types/IFabric';
+import { materialService } from '@/services/material.service';
+
+export const useMaterials = () => {
+    const [materials, setMaterials] = useState<Material[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchMaterials = async () => {
+            try {
+                setIsLoading(true);
+                const data = await materialService.getAll();
+                setMaterials(data);
+                setError(null);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'Error al cargar materiales');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchMaterials();
+    }, []);
+
+    return { materials, isLoading, error };
+};

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -67,9 +67,9 @@ export const useProducts = (options?: UseProductsOptions) => {
 
     const handleAddProduct = (collectionId?: number) => {
         if (collectionId) {
-            router.push(`/productos/crear?coleccionId=${collectionId}`);
+            router.push(`/colecciones/crear?coleccionId=${collectionId}`);
         } else {
-            router.push('/productos/crear');
+            router.push('/colecciones/crear');
         }
     };
 

--- a/frontend/src/services/garment.service.ts
+++ b/frontend/src/services/garment.service.ts
@@ -3,19 +3,28 @@ import { CreateGarmentPayload } from "@/types/IGarment";
 
 export const garmentService = {
     create: async (data: CreateGarmentPayload): Promise<void> => {
-        const response = await fetch(`${API_CONFIG.getApiUrl('/garments')}`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(data),
+        try {
+            const response = await fetch(`${API_CONFIG.getApiUrl('/productos')}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(data),
+    
+            });
+    
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(
+                    errorData.message ||
+                    `Error ${response.status}: ${response.statusText}`
+                );
+            }
 
-        });
-
-        if (!response.ok) {
-            console.warn('⚠️ Backend respondió con error (esperado mientras se adapta):', response.status);
-        } else {
-            console.log('✅ Request enviado exitosamente al backend');
+            const result = await response.json();
+            return result.data
+        } catch (error) {
+            throw error;
         }
-    }
+    } 
 }

--- a/frontend/src/services/material.service.ts
+++ b/frontend/src/services/material.service.ts
@@ -1,7 +1,31 @@
 import { API_CONFIG } from "@/config/api.config";
-import { MaterialAPIRequest, MaterialAPIResponse } from "@/types/IFabric";
+import { MaterialAPIRequest, MaterialAPIResponse, Material } from "@/types/IFabric";
 
 export const materialService = { 
+    getAll: async (): Promise<Material[]> => {
+        const url = API_CONFIG.getApiUrl('/materiales')
+
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}))
+                throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`)
+            }
+
+            const result = await response.json();
+            return result.data?.data || result.data || [];
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error)
+            throw new Error(errorMessage)
+        }
+    },
+
     create: async (data: MaterialAPIRequest): Promise<MaterialAPIResponse> => {
         const url = API_CONFIG.getApiUrl('/materiales');
 

--- a/frontend/src/types/IFabric.ts
+++ b/frontend/src/types/IFabric.ts
@@ -101,3 +101,24 @@ export interface MaterialAPIResponse {
     createdAt?: string
     updatedAt?: string
 }
+
+export interface Material {
+    id: number;
+    nombre: string;
+    url_imagen: string | null;
+    categoriaId: number;
+    categoria: {
+        id: number;
+        nombre: string;
+        createdAt: string;
+        updatedAt: string;
+    };
+    unidadMedida: string;
+    ancho: number | null;
+    peso: number | null;
+    colores: string[];
+    proveedor: string;
+    precio: number;
+    createdAt: string;
+    updatedAt: string;
+}

--- a/frontend/src/types/IGarment.ts
+++ b/frontend/src/types/IGarment.ts
@@ -29,7 +29,7 @@ export const GarmentSchema = z.object({
         name: z.string(),
         consumption: z.number().positive('El consumo debe ser mayor a 0'),
         unit: z.string(),
-        price: z.number().min(0, 'El precio debe ser mayor o igual a 0')
+        price: z.number().min(0, 'El precio debe ser mayor o igual a 0').optional(),
     })).default([])
         .optional()
         .refine(
@@ -43,16 +43,16 @@ export const GarmentSchema = z.object({
     tempFabricPrice: z.number({ error: 'El precio debe ser un número' }).min(0, 'El precio debe ser mayor o igual a 0').optional(),
 
     tempSupplyName: z.string().optional(),
-    tempSupplyConsumption: z.number( { error: 'El consumo debe ser un número' }).optional(),
+    tempSupplyConsumption: z.number({ error: 'El consumo debe ser un número' }).optional(),
     tempSupplyUnit: z.string().optional(),
     tempSupplyPrice: z.number({ error: 'El precio debe ser un número' }).min(0, 'El precio debe ser mayor o igual a 0').optional(),
 
 
-    laborRate: z.number( { error: 'La tarifa debe ser un número' }).min(0, 'La tarifa debe ser mayor o igual a 0').optional(),
-    laborHours: z.number( { error: 'Las horas deben ser un número' }).min(0, 'Las horas deben ser mayor o igual a 0').optional(),
-    wasteMaterial: z.number( { error: 'La merma debe ser un número' }).min(0, 'La merma debe ser mayor o igual a 0').optional(),
+    laborRate: z.number({ error: 'La tarifa debe ser un número' }).min(0, 'La tarifa debe ser mayor o igual a 0').optional(),
+    laborHours: z.number({ error: 'Las horas deben ser un número' }).min(0, 'Las horas deben ser mayor o igual a 0').optional(),
+    wasteMaterial: z.number({ error: 'La merma debe ser un número' }).min(0, 'La merma debe ser mayor o igual a 0').optional(),
     wasteUnit: z.string().optional(),
-    wastePrice: z.number( { error: 'El precio debe ser un número' }).min(0, 'El precio debe ser mayor o igual a 0').optional(),
+    wastePrice: z.number({ error: 'El precio debe ser un número' }).min(0, 'El precio debe ser mayor o igual a 0').optional(),
 
 });
 
@@ -60,26 +60,35 @@ export const GarmentSchema = z.object({
 export type GarmentFormData = z.infer<typeof GarmentSchema>;
 
 export interface CreateGarmentPayload {
-  nombre: string;
-  descripcion?: string;
-  activo: boolean;
-  tallas: string[];
-  colores: string[];
+    codigo: string;
+    nombre: string;
+    descripcion?: string;
+    activo: boolean;
+    imagen: string;
+    tallas: string[];
+    colores: string[];
 
-  rawMaterials: RawMaterial[];
+    coleccionId: number;
 
-  laborRate: number;
-  laborHours: number;
-  wasteMaterial: number;
-  wasteUnit: string;
-  wastePrice: number;
+    materiales?: Array<{
+        materialId: number;
+        cantidad: number;
+    }>;
+
+    manoDeObra?: Array<{
+        accionId: number;
+        horas: number;
+    }>;
+
+    mermaCantidad?: number;
+    mermaUnidad?: string;
+    mermaPrecio?: number;
 }
 
 export interface RawMaterial {
-  id: string;
-  type: string;
-  name: string;
-  consumption: number;
-  unit: string;
-  price: number;
+    materialId: number;
+    nombre: string;
+    cantidad: number;
+    unidadMedida: string;
+    precioTotal: number;
 }


### PR DESCRIPTION
Esta PR contiene una actualización del flujo para crear ficha de prenda

- Navegación desde la página de colecciones con una colección seleccionada > mira listado de productos relacionados por el id de la colección > Botón + para añadir producto como ficha de prenda > Formulario con tres pestañas Detalle, Material y producción
- Endpoints consumidos de productos para crear y materiales para listar materiales al seleccionar materiales listados por su categoría en la pestaña de materiales del formulario
- Botón de guardar que hace la acción y lo envía al backend con el producto creado y se navega a la pantalla anterior del listado y aparecerá el producto nuevo creado

Hubo unos ligeros cambios de backend que afectaba al frontend

- Agregar campo 'imagen' a CreateProductoDtoDB interface
- Incluir mapeo de 'imagen' en producto.service.ts

El campo `imagen` se enviaba desde el frontend pero se almacenaba como `null` en la base de datos.

Solución

- ✅ Agregado campo `imagen?: string` a `CreateProductoDtoDB` interface
- ✅ Incluido `imagen: data.imagen` en el mapeo de `producto.service.ts`
- Corregir body opcional en materialQuerySchema para GET requests

El endpoint GET `/materiales` retornaba 400 porque el schema exigía `body` (innecesario en GET).

<img width="1490" height="289" alt="image" src="https://github.com/user-attachments/assets/49fecfe6-fcd0-4b90-8969-e3b3e6360e39" />


Solución:

✅ Hecho `body` opcional en `materialQuerySchema` con `.optional()`

```tsx
body: z.object({}).optional(),
```